### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/displayengine/userinterface.py
+++ b/displayengine/userinterface.py
@@ -83,12 +83,12 @@ class GLWidget(QtOpenGL.QGLWidget):
         glTranslated(0.0, 0.0, -40.0)
 
     def mousePressEvent(self, event):
-        print "dx %d" % event.x()
-        print "dy %d" % event.y()
+        print "dx {0:d}".format(event.x())
+        print "dy {0:d}".format(event.y())
 
     def mouseMoveEvent(self, event):
-        print "dx %d" % event.x()
-        print "dy %d" % event.y()
+        print "dx {0:d}".format(event.x())
+        print "dy {0:d}".format(event.y())
 
 
 class UserInterface(QtGui.QMainWindow):

--- a/gui/control.py
+++ b/gui/control.py
@@ -43,7 +43,7 @@ class Bounds(object):
         return abs(self.left_top.y - self.right_bottom.y)
 
     def print_me(self):
-        print "top x=%d y=%d, bottom x=%d y=%d" % (self.left_top.x, self.left_top.y, self.right_bottom.x, self.right_bottom.y)
+        print "top x={0:d} y={1:d}, bottom x={2:d} y={3:d}".format(self.left_top.x, self.left_top.y, self.right_bottom.x, self.right_bottom.y)
 
 
 class Control(object):

--- a/gui/testbed.py
+++ b/gui/testbed.py
@@ -66,12 +66,12 @@ class LocalWidget(QtOpenGL.QGLWidget):
         glTranslated(0.0, 0.0, -40.0)
 
     def mousePressEvent(self, event):
-        print "dx %d" % event.x()
-        print "dy %d" % event.y()
+        print "dx {0:d}".format(event.x())
+        print "dy {0:d}".format(event.y())
 
     def mouseMoveEvent(self, event):
-        print "dx %d" % event.x()
-        print "dy %d" % event.y()
+        print "dx {0:d}".format(event.x())
+        print "dy {0:d}".format(event.y())
 
 
 class MainWindow(QtGui.QMainWindow):

--- a/input/samplelogparser.py
+++ b/input/samplelogparser.py
@@ -58,7 +58,7 @@ class LoggingSourceSample(source.Source):
                 line_num += 1
                 result = re.search(meta_regex, line)
                 if result is None:
-                    print "parsing failed for line %s" % line
+                    print "parsing failed for line {0!s}".format(line)
                     continue
 
                 meta = result.group(1)
@@ -103,7 +103,7 @@ class LoggingSourceSample(source.Source):
         return (an_event.date_time - point_b).total_seconds()/span
 
 
-        print str("Total Span is %d" % span)
+        print str("Total Span is {0:d}".format(span))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:satbirsoni:softwaremonitor?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:satbirsoni:softwaremonitor?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
